### PR TITLE
Show background image in crypto section

### DIFF
--- a/Crypto Portal/index.html
+++ b/Crypto Portal/index.html
@@ -44,7 +44,7 @@
             
             <!-- SHERRY you can add text about yourself below -->
             <br>
-            <div class="bio mb-4" style="text-align: center;">Your Gateway Into the Wide World of Crypto
+            <div class="bio mb-4" style="text-align: center; color: #93B5c6">Your Gateway Into the Wide World of Crypto
               
            
             <!--//bio-->

--- a/Crypto Portal/index.html
+++ b/Crypto Portal/index.html
@@ -2,11 +2,6 @@
 <html lang="en">
 
 <head>
-    <style>
-        div {
-          background-image: url('C:\Users\sherr\OneDrive\School 2021\MITxpro\sherryboxall.github.io\Crypto Portal\crypto_image.jpg');
-        }
-        </style>
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -30,8 +25,8 @@
   <!-- Intro section -->
   
   <div class="bg-light">
-    <section class="about-me-section p-3 p-lg-5 theme-bg-light">
-      <div class="container">
+    <section class="about-me-section p-3 p-lg-5 theme-bg-light" style="background-color: transparent; background-image: url('crypto_image.jpg')">
+      <div class="container" >
         <div class="profile-teaser row">
             
           <div class="col" >


### PR DESCRIPTION
Resolves sherryboxall/sherryboxall.github.io#2

I think this is what you were looking to do, but let me know if I put the background image in the wrong section! DM me if you want to know how to do it through the style sheet, for now I just left it as an inline style property. 

I also changed the subtitle to be the same color as the title of that section (it was black text and difficult to read once the background image was in.)